### PR TITLE
Update CentralSystemService15_Service.java

### DIFF
--- a/src/main/java/de/rwth/idsg/steve/service/CentralSystemService15_Service.java
+++ b/src/main/java/de/rwth/idsg/steve/service/CentralSystemService15_Service.java
@@ -15,6 +15,7 @@ import ocpp.cs._2012._06.BootNotificationResponse;
 import ocpp.cs._2012._06.ChargePointStatus;
 import ocpp.cs._2012._06.DataTransferRequest;
 import ocpp.cs._2012._06.DataTransferResponse;
+import ocpp.cs._2012._06.DataTransferStatus;
 import ocpp.cs._2012._06.DiagnosticsStatusNotificationRequest;
 import ocpp.cs._2012._06.DiagnosticsStatusNotificationResponse;
 import ocpp.cs._2012._06.FirmwareStatusNotificationRequest;
@@ -239,6 +240,6 @@ public class CentralSystemService15_Service {
             log.info("[Data Transfer] Data: {}", parameters.getData());
         }
 
-        return new DataTransferResponse();
+        return new DataTransferResponse().withStatus(DataTransferStatus.ACCEPTED);
     }
 }


### PR DESCRIPTION
Even if it's a dummy implementation if this gets called by a Charge Point this will return an "OccurenceConstraintViolation".
According to the OCPP specifications the "DataTransfer.conf" is REQUIRED to return a DataTransferStatus.