### PR TITLE
Fix UpdateFirmware

### DIFF
--- a/src/main/java/de/rwth/idsg/steve/web/dto/ocpp/UpdateFirmwareParams.java
+++ b/src/main/java/de/rwth/idsg/steve/web/dto/ocpp/UpdateFirmwareParams.java
@@ -28,5 +28,6 @@ public class UpdateFirmwareParams extends MultipleChargePointSelect {
     private Integer retryInterval;
 
     @Future(message = "Retrieve Date/Time must be in future")
+    @NotNull(message = "Retrieve Date/Time is required")
     private LocalDateTime retrieve;
 }

--- a/src/main/resources/webapp/WEB-INF/views/op15/UpdateFirmware.jsp
+++ b/src/main/resources/webapp/WEB-INF/views/op15/UpdateFirmware.jsp
@@ -37,7 +37,7 @@
         <tr><td>Retry Interval (integer):</td><td><form:input path="retryInterval" placeholder="optional" /></td></tr>
         <tr><td>Retrieve Date/Time:</td>
             <td>
-                <form:input path="retrieve" placeholder="optional" cssClass="dateTimePicker"/>
+                <form:input path="retrieve" cssClass="dateTimePicker"/>
             </td>
         </tr>
     </table>


### PR DESCRIPTION
Was able to call Update Firmware without the retrieveDate parameter.

Absence of the retrieveDate paramater will cause an "OccurenceConstraintViolation". As described in the OCPP specification, this parameter is mandatory.