### PR TITLE
Fix missing import in UpdateFirmwareParams

### DIFF
--- a/src/main/java/de/rwth/idsg/steve/web/dto/ocpp/UpdateFirmwareParams.java
+++ b/src/main/java/de/rwth/idsg/steve/web/dto/ocpp/UpdateFirmwareParams.java
@@ -8,6 +8,7 @@ import org.joda.time.LocalDateTime;
 import javax.validation.constraints.Future;
 import javax.validation.constraints.Min;
 import javax.validation.constraints.Pattern;
+import javax.validation.constraints.NotNull;
 
 /**
  * @author Sevket Goekay <goekay@dbis.rwth-aachen.de>


### PR DESCRIPTION
Missing import "import javax.validation.constraints.NotNull;" in UpdateFirmwareParams