### PR TITLE
Revert "Bump flyway-maven-plugin from 5.2.4 to 6.0.0"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -288,7 +288,7 @@
             <plugin>
                 <groupId>org.flywaydb</groupId>
                 <artifactId>flyway-maven-plugin</artifactId>
-                <version>6.0.0</version>
+                <version>5.2.4</version>
 
                 <!-- Must be in the same phase as Jooq -->
                 <executions>


### PR DESCRIPTION
Reverts RWTH-i5-IDSG/steve#176

issue with flyway. tracked in https://github.com/flyway/flyway/issues/2481