### PR TITLE
Enable Deployment to Heroku

### DIFF
--- a/src/main/java/de/rwth/idsg/steve/SteveConfiguration.java
+++ b/src/main/java/de/rwth/idsg/steve/SteveConfiguration.java
@@ -66,11 +66,22 @@ public enum SteveConfiguration {
         gitDescribe = useFallbackIfNotSet(p.getOptionalString("git.describe"), null);
         profile = ApplicationProfile.fromName(p.getString("profile"));
 
+        // Enabled deployment on Heroku by checking for environment variable PORT
+        String serverHost = null;
+        int port;
+        String portEnvVar = System.getenv("PORT");
+        if (portEnvVar != null) {
+            port = Integer.parseInt(portEnvVar);
+        } else {
+            port = p.getInt("http.port");
+            serverHost = p.getString("server.host");
+        }
+
         jetty = Jetty.builder()
-                     .serverHost(p.getString("server.host"))
+                     .serverHost(serverHost)
                      .gzipEnabled(p.getBoolean("server.gzip.enabled"))
                      .httpEnabled(p.getBoolean("http.enabled"))
-                     .httpPort(p.getInt("http.port"))
+                     .httpPort(port)
                      .httpsEnabled(p.getBoolean("https.enabled"))
                      .httpsPort(p.getInt("https.port"))
                      .keyStorePath(p.getOptionalString("keystore.path"))

--- a/src/main/resources/config/prod/log4j2.xml
+++ b/src/main/resources/config/prod/log4j2.xml
@@ -18,6 +18,9 @@
             </Policies>
             <DefaultRolloverStrategy max="20"/>
         </RollingRandomAccessFile>
+        <Console name="STDOUT" target="SYSTEM_OUT">
+            <PatternLayout pattern="${logPattern}"/>
+        </Console>
     </Appenders>
 
     <Loggers>
@@ -31,6 +34,7 @@
 
         <AsyncRoot level="INFO">
             <AppenderRef ref="FILE"/>
+            <AppenderRef ref="STDOUT"/>
         </AsyncRoot>
     </Loggers>
 </Configuration>


### PR DESCRIPTION
In order for SteVe to be deployed on [Heroku](https://www.heroku.com) (and likely other cloud hosting providers) the internal Jetty server needs to be able to be dynamically configured externally.  Specifically, it needs to be able to have its `port` and `serverHost` configured at launch time.

This change is Heroku specific in that it checks for the `PORT` environment variable and if found sets Jetty to use that value and sets the `serverHost` to null so that SteVe can bind to it's hosting environment.  If this environment variable is not found, SteVe runs as originally designed using the `http.port` and `server.host` from `main.properties`.  For more details please see:

https://devcenter.heroku.com/articles/setting-the-http-port-for-java-applications

Relatedly, another way around this issue would be for SteVe to be refactored to support being run as an external .war file using [Jetty Runner](https://www.eclipse.org/jetty/documentation/9.4.x/runner.html) or [Heroku Webapp Runner](https://devcenter.heroku.com/articles/java-webapp-runner).

Thanks for considering this change!

/cc @goekay 

