### PR TITLE
Revert "Bump flyway-maven-plugin from 6.3.1 to 6.3.2"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -288,7 +288,7 @@
             <plugin>
                 <groupId>org.flywaydb</groupId>
                 <artifactId>flyway-maven-plugin</artifactId>
-                <version>6.3.2</version>
+                <version>6.3.1</version>
 
                 <!-- Must be in the same phase as Jooq -->
                 <executions>


### PR DESCRIPTION
Reverts RWTH-i5-IDSG/steve#313

breaks build during schema migration for new installs: 
https://travis-ci.org/github/RWTH-i5-IDSG/steve/builds/666328144
(happens on my local machine as well)

PS: for some reason travis-ci doesnt show it's status in the pull/merge dialog. Couldnt find out why yet.

```
[ERROR] Failed to execute goal org.flywaydb:flyway-maven-plugin:6.3.2:migrate (default) on project steve: org.flywaydb.core.api.FlywayException: Unable to parse statement in /home/travis/build/RWTH-i5-IDSG/steve/src/main/resources/db/migration/V0_9_7__update.sql at line 5 col 1: Incomplete statement at line 5 col 1: CREATE OR REPLACE VIEW ocpp_tag_activity AS
[ERROR]     SELECT
[ERROR]       ocpp_tag.*,
[ERROR]       COALESCE(tx_activity.active_transaction_count, 0) as 'active_transaction_count',
[ERROR]       CASE WHEN (active_transaction_count > 0) THEN TRUE ELSE FALSE END AS 'in_transaction'
[ERROR]     FROM ocpp_tag
[ERROR]     LEFT JOIN
[ERROR]     (SELECT id_tag, count(id_tag) as 'active_transaction_count'
[ERROR]       FROM transaction
[ERROR]       WHERE stop_timestamp IS NULL
[ERROR]       AND stop_value IS NULL
[ERROR]       GROUP BY id_tag) tx_activity
[ERROR]     ON ocpp_tag.id_tag = tx_activity.id_tag;
[ERROR] -> [Help 1]
```