### PR TITLE
switch back to mysql for travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,8 @@ sudo: false
 language: java
 dist: xenial
 jdk: openjdk11
-# services: mysql
+services:
+        - mysql
 
 # install dependencies
 install: mvn dependency:go-offline -s .travis-maven-settings.xml -B -V
@@ -26,7 +27,6 @@ script:
 
 
 addons:
-        mariadb: "10.3"
         apt:
                 packages:
                         - elinks


### PR DESCRIPTION
some time ago, for some undocumented reason we started using mariadb for travis ci (maybe travis had better support for mariadb than for mysql?). recently, that caused a problem in https://github.com/RWTH-i5-IDSG/steve/pull/434. maybe we can consider switching back to mysql.

@csamsel FYI