### PR TITLE
replace go-offline command

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: java
 
 
 # install dependencies
-install: mvn dependency:go-offline -s .travis-maven-settings.xml -B -V
+install: mvn dependency:resolve dependency:resolve-plugins -s .travis-maven-settings.xml -B -V
 
 before_script:
   # Display Versions


### PR DESCRIPTION
reason: the command cannot find dependencies outside the maven central
(our case: jitpack). it seems to be a common understanding that this
command is broken.
- same problem different context:
  https://www.mail-archive.com/issues@maven.apache.org/msg161649.html
- alternative plugin that presents go-offline's shortcomings:
  https://github.com/qaware/go-offline-maven-plugin

this PR will unblock https://github.com/RWTH-i5-IDSG/steve/pull/493