### PR TITLE
respect X-Forwarded-For headers if present

### DIFF
--- a/src/main/java/de/rwth/idsg/steve/JettyServer.java
+++ b/src/main/java/de/rwth/idsg/steve/JettyServer.java
@@ -22,13 +22,7 @@ import de.rwth.idsg.steve.web.dto.EndpointInfo;
 import lombok.extern.slf4j.Slf4j;
 import org.eclipse.jetty.http.HttpScheme;
 import org.eclipse.jetty.http.HttpVersion;
-import org.eclipse.jetty.server.Connector;
-import org.eclipse.jetty.server.HttpConfiguration;
-import org.eclipse.jetty.server.HttpConnectionFactory;
-import org.eclipse.jetty.server.SecureRequestCustomizer;
-import org.eclipse.jetty.server.Server;
-import org.eclipse.jetty.server.ServerConnector;
-import org.eclipse.jetty.server.SslConnectionFactory;
+import org.eclipse.jetty.server.*;
 import org.eclipse.jetty.util.ssl.SslContextFactory;
 import org.eclipse.jetty.util.thread.QueuedThreadPool;
 import org.eclipse.jetty.util.thread.ScheduledExecutorScheduler;
@@ -94,6 +88,9 @@ public class JettyServer {
         httpConfig.setSendServerVersion(false);
         httpConfig.setSendDateHeader(false);
         httpConfig.setSendXPoweredBy(false);
+
+        // make sure X-Forwarded-For headers are picked up if set (e.g. by a load balancer)
+        httpConfig.addCustomizer(new ForwardedRequestCustomizer());
 
         // Extra options
         server.setDumpAfterStart(false);


### PR DESCRIPTION
A classical setup is to terminate HTTPS on a load balancer, but communicate with HTTP between load balancer and backend service.

In this case, the load balancer would add X-Forwarded-For headers to the HTTP requests, such that the backend application would know e.g. for redirects where to redirect the user to.

For this to work, these headers must be picked up by the Jetty server. This is accomplished by adding the ForwardedRequestCustomizer to the http config:
- If the headers are present, they will be used
- If the headers are not present, nothing changes

As Steve is making heavy use of redirects, we cannot run the app behind an AWS load balancer while terminating HTTPS on the load balancer.