### PR TITLE
remove mariadb 10.3 from travis build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,23 +46,6 @@ jobs:
       jdk: openjdk15
       dist: xenial
       services: mysql
-      
-    - name: OpenJDK11 with MariaDB 10.3 (Ubuntu LTS 20.04)
-      jdk: openjdk11
-      dist: focal
-      addons:
-        mariadb: "10.3"
-        apt:
-          packages:
-            - elinks
-    - name: OpenJDK15 with MariaDB 10.3 (Ubuntu LTS 20.04)
-      jdk: openjdk15
-      dist: focal
-      addons:
-        mariadb: "10.3"
-        apt:
-          packages:
-            - elinks
     - name: OpenJDK11 with MariaDB 10.5 (Ubuntu LTS 20.04)
       jdk: openjdk11
       dist: focal


### PR DESCRIPTION
travis build jobs including 10.3 fail. the reason seems to be related to ubuntu failing to pull the dependency.

build: https://travis-ci.org/github/RWTH-i5-IDSG/steve/builds/771313119
failing job: https://travis-ci.org/github/RWTH-i5-IDSG/steve/jobs/771313124

<details>
<summary>the relevant part from travis logs</summary>

```
Installing MariaDB version 10.3
Executing: /tmp/apt-key-gpghome.VLe3J0EGMC/gpg.1.sh --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 0xf1656f24c74cd1d8
gpg: key F1656F24C74CD1D8: public key "MariaDB Signing Key <signing-key@mariadb.org>" imported
gpg: Total number processed: 1
gpg:               imported: 1
Hit:1 http://security.ubuntu.com/ubuntu focal-security InRelease
Ign:2 https://repo.mongodb.org/apt/ubuntu bionic/mongodb-org/4.2 InRelease
Hit:3 https://repo.mongodb.org/apt/ubuntu bionic/mongodb-org/4.2 Release
Get:4 http://nyc2.mirrors.digitalocean.com/mariadb/repo/10.3/ubuntu focal InRelease [6,264 B]
Ign:5 https://packages.erlang-solutions.com/ubuntu focal InRelease
Hit:6 https://public.dhe.ibm.com/software/server/POWER/Linux/toolchain/at/ubuntu focal InRelease
Hit:7 https://packages.erlang-solutions.com/ubuntu focal Release
Hit:8 http://archive.ubuntu.com/ubuntu focal InRelease
Hit:10 http://archive.ubuntu.com/ubuntu focal-updates InRelease
Get:11 http://nyc2.mirrors.digitalocean.com/mariadb/repo/10.3/ubuntu focal/main amd64 Packages [16.2 kB]
Hit:12 http://archive.ubuntu.com/ubuntu focal-backports InRelease
Fetched 22.4 kB in 1s (30.5 kB/s)
Reading package lists... Done
N: Skipping acquire of configured file 'main/binary-i386/Packages' as repository 'http://nyc2.mirrors.digitalocean.com/mariadb/repo/10.3/ubuntu focal InRelease' doesn't support architecture 'i386'
$ travis_apt_get_update
$ PACKAGES='mariadb-server-10.3'
$ if [[ $(lsb_release -cs) = 'precise' ]]; then PACKAGES="${PACKAGES} libmariadbclient-dev"; fi
0.47s$ sudo apt-get install -y -o Debug::pkgProblemResolver=yes -o Dpkg::Options::='--force-confnew' $PACKAGES
Reading package lists... Done
Building dependency tree       
Reading state information... Done
Starting pkgProblemResolver with broken count: 3
Starting 2 pkgProblemResolver with broken count: 3
Investigating (0) mariadb-server-10.3:amd64 < none -> 1:10.3.29+maria~focal @un puN Ib >
Broken mariadb-server-10.3:amd64 Depends on mariadb-client-10.3:amd64 < none | 1:10.3.29+maria~focal @un uH > (>= 1:10.3.29+maria~focal)
  Considering mariadb-client-10.3:amd64 -2 as a solution to mariadb-server-10.3:amd64 9998
  Re-Instated mariadb-client-core-10.3:amd64
  Re-Instated mariadb-client-10.3:amd64
Broken mariadb-server-10.3:amd64 Depends on mariadb-server-core-10.3:amd64 < none | 1:10.3.29+maria~focal @un uH > (>= 1:10.3.29+maria~focal)
  Considering mariadb-server-core-10.3:amd64 -1 as a solution to mariadb-server-10.3:amd64 9998
  Re-Instated mariadb-server-core-10.3:amd64
Broken mariadb-server-10.3:amd64 Conflicts on mysql-server:amd64 < 8.0.23-0ubuntu0.20.04.1 -> 8.0.25-0ubuntu0.20.04.1 @ii umU Ib > (< 1:10.3.29+maria~focal)
  Considering mysql-server:amd64 -1 as a solution to mariadb-server-10.3:amd64 9998
  Added mysql-server:amd64 to the remove list
  Conflicts//Breaks against version 8.0.23-0ubuntu0.20.04.1 for mysql-server but that is not InstVer, ignoring
  Conflicts//Breaks against version 8.0.19-0ubuntu5 for mysql-server but that is not InstVer, ignoring
  Fixing mariadb-server-10.3:amd64 via remove of mysql-server:amd64
Investigating (0) mysql-client-core-8.0:amd64 < 8.0.23-0ubuntu0.20.04.1 -> 8.0.25-0ubuntu0.20.04.1 @ii umU Ib >
Broken mysql-client-core-8.0:amd64 Conflicts on mariadb-client-10.3:amd64 < none -> 1:10.3.29+maria~focal @un uN Ib >
  Considering mariadb-client-10.3:amd64 -2 as a solution to mysql-client-core-8.0:amd64 2
  Added mariadb-client-10.3:amd64 to the remove list
  Conflicts//Breaks against version 1:10.3.29-0ubuntu0.20.04.1 for mariadb-client-10.3 but that is not InstVer, ignoring
  Conflicts//Breaks against version 1:10.3.28+maria~focal for mariadb-client-10.3 but that is not InstVer, ignoring
  Conflicts//Breaks against version 1:10.3.27+maria~focal for mariadb-client-10.3 but that is not InstVer, ignoring
  Conflicts//Breaks against version 1:10.3.22-1ubuntu1 for mariadb-client-10.3 but that is not InstVer, ignoring
Broken mysql-client-core-8.0:amd64 Conflicts on mariadb-client-core-10.3:amd64 < none -> 1:10.3.29+maria~focal @un uN Ib >
  Considering mariadb-client-core-10.3:amd64 -1 as a solution to mysql-client-core-8.0:amd64 2
  Added mariadb-client-core-10.3:amd64 to the remove list
  Conflicts//Breaks against version 1:10.3.29-0ubuntu0.20.04.1 for mariadb-client-core-10.3 but that is not InstVer, ignoring
  Conflicts//Breaks against version 1:10.3.28+maria~focal for mariadb-client-core-10.3 but that is not InstVer, ignoring
  Conflicts//Breaks against version 1:10.3.27+maria~focal for mariadb-client-core-10.3 but that is not InstVer, ignoring
  Conflicts//Breaks against version 1:10.3.22-1ubuntu1 for mariadb-client-core-10.3 but that is not InstVer, ignoring
Broken mysql-client-core-8.0:amd64 Conflicts on mysql-client-5.7:amd64 < none @un H >
  Conflicts//Breaks against version 1:10.3.27+maria~focal for mariadb-client-10.3 but that is not InstVer, ignoring
  Conflicts//Breaks against version 1:10.3.28+maria~focal for mariadb-client-10.3 but that is not InstVer, ignoring
  Considering mariadb-client-10.3:amd64 -2 as a solution to mysql-client-core-8.0:amd64 2
  Added mariadb-client-10.3:amd64 to the remove list
Broken mysql-client-core-8.0:amd64 Conflicts on mysql-client-core-5.7:amd64 < none @un H >
  Conflicts//Breaks against version 1:10.3.27+maria~focal for mariadb-client-core-10.3 but that is not InstVer, ignoring
  Conflicts//Breaks against version 1:10.3.28+maria~focal for mariadb-client-core-10.3 but that is not InstVer, ignoring
  Considering mariadb-client-core-10.3:amd64 -1 as a solution to mysql-client-core-8.0:amd64 2
  Added mariadb-client-core-10.3:amd64 to the remove list
Broken mysql-client-core-8.0:amd64 Conflicts on virtual-mysql-client-core:amd64 < none @un H >
  Conflicts//Breaks against version 1:10.3.27+maria~focal for mariadb-client-core-10.3 but that is not InstVer, ignoring
  Conflicts//Breaks against version 1:10.3.28+maria~focal for mariadb-client-core-10.3 but that is not InstVer, ignoring
  Considering mariadb-client-core-10.3:amd64 -1 as a solution to mysql-client-core-8.0:amd64 2
  Added mariadb-client-core-10.3:amd64 to the remove list
  Conflicts//Breaks against version 1:10.3.29-0ubuntu0.20.04.1 for mariadb-client-core-10.3 but that is not InstVer, ignoring
  Conflicts//Breaks against version 1:10.3.22-1ubuntu1 for mariadb-client-core-10.3 but that is not InstVer, ignoring
  Fixing mysql-client-core-8.0:amd64 via keep of mariadb-client-10.3:amd64
  Fixing mysql-client-core-8.0:amd64 via keep of mariadb-client-core-10.3:amd64
  Fixing mysql-client-core-8.0:amd64 via keep of mariadb-client-10.3:amd64
  Fixing mysql-client-core-8.0:amd64 via keep of mariadb-client-core-10.3:amd64
  Fixing mysql-client-core-8.0:amd64 via keep of mariadb-client-core-10.3:amd64
Investigating (0) mysql-server-core-8.0:amd64 < 8.0.23-0ubuntu0.20.04.1 -> 8.0.25-0ubuntu0.20.04.1 @ii umU Ib >
Broken mysql-server-core-8.0:amd64 Conflicts on mariadb-server-10.3:amd64 < none -> 1:10.3.29+maria~focal @un puN Ib >
  Considering mariadb-server-10.3:amd64 9998 as a solution to mysql-server-core-8.0:amd64 0
    Reinst Failed because of protected mariadb-server-10.3:amd64
  Removing mysql-server-core-8.0:amd64 rather than change mariadb-server-10.3:amd64
Investigating (1) mariadb-server-10.3:amd64 < none -> 1:10.3.29+maria~focal @un puN Ib >
Broken mariadb-server-10.3:amd64 Depends on mariadb-client-10.3:amd64 < none | 1:10.3.29+maria~focal @un uH > (>= 1:10.3.29+maria~focal)
  Considering mariadb-client-10.3:amd64 -2 as a solution to mariadb-server-10.3:amd64 9998
Done
Some packages could not be installed. This may mean that you have
requested an impossible situation or if you are using the unstable
distribution that some required packages have not yet been created
or been moved out of Incoming.
The following information may help to resolve the situation:
The following packages have unmet dependencies:
 mariadb-server-10.3 : Depends: mariadb-client-10.3 (>= 1:10.3.29+maria~focal) but it is not going to be installed
E: Unable to correct problems, you have held broken packages.
Starting MariaDB v10.3
0.05s$ sudo systemctl start mysql
Job for mysql.service failed because the control process exited with error code.
See "systemctl status mysql.service" and "journalctl -xe" for details.
$ mysql --version
mysql  Ver 8.0.23-0ubuntu0.20.04.1 for Linux on x86_64 ((Ubuntu))
```

</details>

other people face the issue as well: https://askubuntu.com/questions/1337745/ubuntu-20-04-weird-problems-on-mariadb-server-10-3-upgrade/1338051#1338051