### PR TITLE
add mariadb 10.3 to travis build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,6 +46,22 @@ jobs:
       jdk: openjdk15
       dist: xenial
       services: mysql
+    - name: OpenJDK11 with MariaDB 10.3 (Ubuntu LTS 20.04)
+      jdk: openjdk11
+      dist: focal
+      addons:
+        mariadb: "10.3"
+        apt:
+          packages:
+            - elinks
+    - name: OpenJDK15 with MariaDB 10.3 (Ubuntu LTS 20.04)
+      jdk: openjdk15
+      dist: focal
+      addons:
+        mariadb: "10.3"
+        apt:
+          packages:
+            - elinks
     - name: OpenJDK11 with MariaDB 10.5 (Ubuntu LTS 20.04)
       jdk: openjdk11
       dist: focal


### PR DESCRIPTION
context: https://github.com/RWTH-i5-IDSG/steve/pull/582

track the issue and merge this PR once it does not fail anymore.