### PR TITLE
getChargePointConnectorStatus respects only Accepted stations (#691)

### DIFF
--- a/src/main/java/de/rwth/idsg/steve/repository/impl/ChargePointRepositoryImpl.java
+++ b/src/main/java/de/rwth/idsg/steve/repository/impl/ChargePointRepositoryImpl.java
@@ -32,6 +32,7 @@ import de.rwth.idsg.steve.web.dto.ConnectorStatusForm;
 import jooq.steve.db.tables.records.AddressRecord;
 import jooq.steve.db.tables.records.ChargeBoxRecord;
 import lombok.extern.slf4j.Slf4j;
+import ocpp.cs._2015._10.RegistrationStatus;
 import org.joda.time.DateTime;
 import org.jooq.Condition;
 import org.jooq.DSLContext;
@@ -220,11 +221,11 @@ public class ChargePointRepositoryImpl implements ChargePointRepository {
                             .and(CONNECTOR_STATUS.STATUS_TIMESTAMP.equal(t1.field(t1TsMax)))
                          .asTable("t2");
 
-        final Condition chargeBoxCondition;
-        if (form == null || form.getChargeBoxId() == null) {
-            chargeBoxCondition = DSL.noCondition();
-        } else {
-            chargeBoxCondition = CHARGE_BOX.CHARGE_BOX_ID.eq(form.getChargeBoxId());
+        // https://github.com/RWTH-i5-IDSG/steve/issues/691
+        Condition chargeBoxCondition = CHARGE_BOX.REGISTRATION_STATUS.eq(RegistrationStatus.ACCEPTED.value());
+
+        if (form != null && form.getChargeBoxId() != null) {
+            chargeBoxCondition = chargeBoxCondition.and(CHARGE_BOX.CHARGE_BOX_ID.eq(form.getChargeBoxId()));
         }
 
         final Condition statusCondition;


### PR DESCRIPTION
**problem:**

even though we have the registration status information in database, we are currently not considering it to filter out connector status information of rejected stations.

reported in https://github.com/RWTH-i5-IDSG/steve/issues/691

**notes about solution:**

- the latest ocpp version we support (version 1.6) determines 3 registration status values: Accepted, Pending, Rejected. according to spec definition of Pending: "Central System is not yet ready to accept the Charge Point. Central System may send messages to retrieve information or prepare the Charge Point." it seems like the right thing to do to allow connector status information of only _Accepted_ stations. 
- we are not considering this status in other components/flows either where we retrieve the station information from database. i left these deliberately as they are in order to not break existing workflows.