### PR TITLE
Update log4j to 2.16.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -459,7 +459,7 @@
             <dependency>
                 <groupId>org.apache.logging.log4j</groupId>
                 <artifactId>log4j-bom</artifactId>
-                <version>2.15.0</version>
+                <version>2.16.0</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>


### PR DESCRIPTION
Update log4j to the latest version.
Apache Log4j 2.15.0 was incomplete in certain non-default configurations CVE-2021-45046