### PR TITLE
Update log4j2 version to 2.17.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -459,7 +459,7 @@
             <dependency>
                 <groupId>org.apache.logging.log4j</groupId>
                 <artifactId>log4j-bom</artifactId>
-                <version>2.16.0</version>
+                <version>2.17.0</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>


### PR DESCRIPTION
Hello,

Log4j2 version 2.17.0 fixes another vulnerability in the log4j2 library: CVE-2021-45105 (see https://logging.apache.org/log4j/2.x/security.html).
The mentioned vulnerability gives an attacker a way to perform a Denial of Service attack when using certain non-default configurations.

Best regards,
Kowsz