### PR TITLE
improve websocket handshake logic

### DIFF
--- a/src/main/java/de/rwth/idsg/steve/ocpp/ws/AbstractWebSocketEndpoint.java
+++ b/src/main/java/de/rwth/idsg/steve/ocpp/ws/AbstractWebSocketEndpoint.java
@@ -31,11 +31,13 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.socket.BinaryMessage;
 import org.springframework.web.socket.CloseStatus;
 import org.springframework.web.socket.PongMessage;
+import org.springframework.web.socket.SubProtocolCapable;
 import org.springframework.web.socket.TextMessage;
 import org.springframework.web.socket.WebSocketMessage;
 import org.springframework.web.socket.WebSocketSession;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Deque;
 import java.util.List;
 import java.util.Map;
@@ -48,7 +50,7 @@ import java.util.function.Consumer;
  * @author Sevket Goekay <sevketgokay@gmail.com>
  * @since 17.03.2015
  */
-public abstract class AbstractWebSocketEndpoint extends ConcurrentWebSocketHandler {
+public abstract class AbstractWebSocketEndpoint extends ConcurrentWebSocketHandler implements SubProtocolCapable {
 
     @Autowired private ScheduledExecutorService service;
     @Autowired private OcppServerRepository ocppServerRepository;
@@ -71,6 +73,11 @@ public abstract class AbstractWebSocketEndpoint extends ConcurrentWebSocketHandl
 
         connectedCallbackList.add((chargeBoxId) -> notificationService.ocppStationWebSocketConnected(chargeBoxId));
         disconnectedCallbackList.add((chargeBoxId) -> notificationService.ocppStationWebSocketDisconnected(chargeBoxId));
+    }
+
+    @Override
+    public List<String> getSubProtocols() {
+        return Collections.singletonList(getVersion().getValue());
     }
 
     @Override

--- a/src/main/java/de/rwth/idsg/steve/ocpp/ws/OcppWebSocketHandshakeHandler.java
+++ b/src/main/java/de/rwth/idsg/steve/ocpp/ws/OcppWebSocketHandshakeHandler.java
@@ -20,34 +20,48 @@ package de.rwth.idsg.steve.ocpp.ws;
 
 import de.rwth.idsg.steve.service.ChargePointHelperService;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import ocpp.cs._2015._10.RegistrationStatus;
 import org.jetbrains.annotations.Nullable;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.server.ServerHttpRequest;
 import org.springframework.http.server.ServerHttpResponse;
-import org.springframework.web.socket.WebSocketExtension;
+import org.springframework.util.CollectionUtils;
 import org.springframework.web.socket.WebSocketHandler;
+import org.springframework.web.socket.WebSocketHttpHeaders;
+import org.springframework.web.socket.handler.TextWebSocketHandler;
 import org.springframework.web.socket.server.HandshakeFailureException;
-import org.springframework.web.socket.server.jetty.Jetty10RequestUpgradeStrategy;
+import org.springframework.web.socket.server.HandshakeHandler;
+import org.springframework.web.socket.server.support.DefaultHandshakeHandler;
 
-import java.security.Principal;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
 /**
  * @author Sevket Goekay <sevketgokay@gmail.com>
- * @since 13.03.2015
+ * @since 05.03.2022
  */
+@Slf4j
 @RequiredArgsConstructor
-public class OcppWebSocketUpgrader extends Jetty10RequestUpgradeStrategy {
+public class OcppWebSocketHandshakeHandler implements HandshakeHandler {
 
+    private final DefaultHandshakeHandler delegate;
     private final List<AbstractWebSocketEndpoint> endpoints;
     private final ChargePointHelperService chargePointHelperService;
 
+    /**
+     * We need some WebSocketHandler just for Spring to register it for the path. We will not use it for the actual
+     * operations. This instance will be passed to doHandshake(..) below. We will find the proper WebSocketEndpoint
+     * based on the selectedProtocol and replace the dummy one with the proper one in the subsequent call chain.
+     */
+    public WebSocketHandler getDummyWebSocketHandler() {
+        return new TextWebSocketHandler();
+    }
+
     @Override
-    public void upgrade(ServerHttpRequest request, ServerHttpResponse response,
-                        String selectedProtocol, List<WebSocketExtension> selectedExtensions, Principal user,
-                        WebSocketHandler wsHandler, Map<String, Object> attributes) throws HandshakeFailureException {
+    public boolean doHandshake(ServerHttpRequest request, ServerHttpResponse response,
+                               WebSocketHandler wsHandler, Map<String, Object> attributes) throws HandshakeFailureException {
 
         // -------------------------------------------------------------------------
         // 1. Check the chargeBoxId
@@ -62,25 +76,35 @@ public class OcppWebSocketUpgrader extends Jetty10RequestUpgradeStrategy {
         if (allowConnection) {
             attributes.put(AbstractWebSocketEndpoint.CHARGEBOX_ID_KEY, chargeBoxId);
         } else {
-            throw new HandshakeFailureException("ChargeBoxId '" + chargeBoxId + "' is not recognized.");
+            log.error("ChargeBoxId '{}' is not recognized.", chargeBoxId);
+            response.setStatusCode(HttpStatus.UNAUTHORIZED);
+            return false;
         }
 
         // -------------------------------------------------------------------------
         // 2. Route according to the selected protocol
         // -------------------------------------------------------------------------
 
-        if (selectedProtocol == null) {
-            throw new HandshakeFailureException("No protocol (OCPP version) is specified.");
+        List<String> wantedProtocols = new WebSocketHttpHeaders(request.getHeaders()).getSecWebSocketProtocol();
+
+        if (CollectionUtils.isEmpty(wantedProtocols)) {
+            log.error("No protocol (OCPP version) is specified.");
+            response.setStatusCode(HttpStatus.BAD_REQUEST);
+            return false;
         }
 
+        String selectedProtocol = wantedProtocols.get(0);
         AbstractWebSocketEndpoint endpoint = findEndpoint(selectedProtocol);
 
         if (endpoint == null) {
-            throw new HandshakeFailureException("Requested protocol '" + selectedProtocol + "' is not supported");
+            log.error("Requested protocol '{}' is not supported", selectedProtocol);
+            response.setStatusCode(HttpStatus.BAD_REQUEST);
+            return false;
         }
 
-        super.upgrade(request, response, selectedProtocol, selectedExtensions, user, endpoint, attributes);
+        return delegate.doHandshake(request, response, endpoint, attributes);
     }
+
 
     @Nullable
     private AbstractWebSocketEndpoint findEndpoint(String selectedProtocol) {

--- a/src/main/java/de/rwth/idsg/steve/ocpp/ws/OcppWebSocketHandshakeHandler.java
+++ b/src/main/java/de/rwth/idsg/steve/ocpp/ws/OcppWebSocketHandshakeHandler.java
@@ -98,7 +98,7 @@ public class OcppWebSocketHandshakeHandler implements HandshakeHandler {
 
         if (endpoint == null) {
             log.error("Requested protocol '{}' is not supported", selectedProtocol);
-            response.setStatusCode(HttpStatus.BAD_REQUEST);
+            response.setStatusCode(HttpStatus.NOT_FOUND);
             return false;
         }
 

--- a/src/main/java/de/rwth/idsg/steve/ocpp/ws/OcppWebSocketHandshakeHandler.java
+++ b/src/main/java/de/rwth/idsg/steve/ocpp/ws/OcppWebSocketHandshakeHandler.java
@@ -102,6 +102,7 @@ public class OcppWebSocketHandshakeHandler implements HandshakeHandler {
             return false;
         }
 
+        log.debug("ChargeBoxId '{}' will be using {}", chargeBoxId, endpoint.getClass().getSimpleName());
         return delegate.doHandshake(request, response, endpoint, attributes);
     }
 

--- a/src/test/java/de/rwth/idsg/steve/ApplicationJsonTest.java
+++ b/src/test/java/de/rwth/idsg/steve/ApplicationJsonTest.java
@@ -143,7 +143,7 @@ public class ApplicationJsonTest {
     @Test
     public void testWithMissingVersion() {
         RuntimeException e = Assertions.assertThrows(RuntimeException.class, () -> {
-            OcppJsonChargePoint chargePoint = new OcppJsonChargePoint(null, REGISTERED_CHARGE_BOX_ID, PATH);
+            OcppJsonChargePoint chargePoint = new OcppJsonChargePoint((String) null, REGISTERED_CHARGE_BOX_ID, PATH);
             chargePoint.start();
         });
 
@@ -152,6 +152,20 @@ public class ApplicationJsonTest {
         UpgradeException actualCause = (UpgradeException) e.getCause().getCause();
 
         Assertions.assertEquals(HttpStatus.BAD_REQUEST.value(), actualCause.getResponseStatusCode());
+    }
+
+    @Test
+    public void testWithWrongVersion() {
+        RuntimeException e = Assertions.assertThrows(RuntimeException.class, () -> {
+            OcppJsonChargePoint chargePoint = new OcppJsonChargePoint("ocpp1234", REGISTERED_CHARGE_BOX_ID, PATH);
+            chargePoint.start();
+        });
+
+        Assertions.assertTrue(e.getCause().getCause() instanceof UpgradeException);
+
+        UpgradeException actualCause = (UpgradeException) e.getCause().getCause();
+
+        Assertions.assertEquals(HttpStatus.NOT_FOUND.value(), actualCause.getResponseStatusCode());
     }
 
     @Test

--- a/src/test/java/de/rwth/idsg/steve/ApplicationJsonTest.java
+++ b/src/test/java/de/rwth/idsg/steve/ApplicationJsonTest.java
@@ -45,7 +45,6 @@ import static de.rwth.idsg.steve.utils.Helpers.getRandomString;
 public class ApplicationJsonTest {
 
     private static final String PATH = "ws://localhost:8080/steve/websocket/CentralSystemService/";
-    private static final OcppVersion VERSION = OcppVersion.V_16;
 
     private static final String REGISTERED_CHARGE_BOX_ID = __DatabasePreparer__.getRegisteredChargeBoxId();
     private static final String REGISTERED_OCPP_TAG =  __DatabasePreparer__.getRegisteredOcppTag();
@@ -70,8 +69,56 @@ public class ApplicationJsonTest {
     }
 
     @Test
+    public void testOcpp12() {
+        OcppJsonChargePoint chargePoint = new OcppJsonChargePoint(OcppVersion.V_12, REGISTERED_CHARGE_BOX_ID, PATH);
+        chargePoint.start();
+
+        ocpp.cs._2010._08.BootNotificationRequest boot = new ocpp.cs._2010._08.BootNotificationRequest()
+            .withChargePointVendor(getRandomString())
+            .withChargePointModel(getRandomString());
+
+        chargePoint.prepare(boot, ocpp.cs._2010._08.BootNotificationResponse.class,
+            bootResponse -> Assertions.assertEquals(ocpp.cs._2010._08.RegistrationStatus.ACCEPTED, bootResponse.getStatus()),
+            error -> Assertions.fail()
+        );
+
+        ocpp.cs._2010._08.AuthorizeRequest auth = new ocpp.cs._2010._08.AuthorizeRequest().withIdTag(REGISTERED_OCPP_TAG);
+
+        chargePoint.prepare(auth, ocpp.cs._2010._08.AuthorizeResponse.class,
+            authResponse -> Assertions.assertEquals(ocpp.cs._2010._08.AuthorizationStatus.ACCEPTED, authResponse.getIdTagInfo().getStatus()),
+            error -> Assertions.fail()
+        );
+
+        chargePoint.processAndClose();
+    }
+
+    @Test
+    public void testOcpp15() {
+        OcppJsonChargePoint chargePoint = new OcppJsonChargePoint(OcppVersion.V_15, REGISTERED_CHARGE_BOX_ID, PATH);
+        chargePoint.start();
+
+        ocpp.cs._2012._06.BootNotificationRequest boot = new ocpp.cs._2012._06.BootNotificationRequest()
+            .withChargePointVendor(getRandomString())
+            .withChargePointModel(getRandomString());
+
+        chargePoint.prepare(boot, ocpp.cs._2012._06.BootNotificationResponse.class,
+            bootResponse -> Assertions.assertEquals(ocpp.cs._2012._06.RegistrationStatus.ACCEPTED, bootResponse.getStatus()),
+            error -> Assertions.fail()
+        );
+
+        ocpp.cs._2012._06.AuthorizeRequest auth = new ocpp.cs._2012._06.AuthorizeRequest().withIdTag(REGISTERED_OCPP_TAG);
+
+        chargePoint.prepare(auth, ocpp.cs._2012._06.AuthorizeResponse.class,
+            authResponse -> Assertions.assertEquals(ocpp.cs._2012._06.AuthorizationStatus.ACCEPTED, authResponse.getIdTagInfo().getStatus()),
+            error -> Assertions.fail()
+        );
+
+        chargePoint.processAndClose();
+    }
+
+    @Test
     public void testOcpp16() {
-        OcppJsonChargePoint chargePoint = new OcppJsonChargePoint(VERSION, REGISTERED_CHARGE_BOX_ID, PATH);
+        OcppJsonChargePoint chargePoint = new OcppJsonChargePoint(OcppVersion.V_16, REGISTERED_CHARGE_BOX_ID, PATH);
         chargePoint.start();
 
         BootNotificationRequest boot = new BootNotificationRequest()
@@ -110,7 +157,7 @@ public class ApplicationJsonTest {
     @Test
     public void tesWithUnauthorizedStation() {
         RuntimeException e = Assertions.assertThrows(RuntimeException.class, () -> {
-            OcppJsonChargePoint chargePoint = new OcppJsonChargePoint(VERSION, "unauth1234", PATH);
+            OcppJsonChargePoint chargePoint = new OcppJsonChargePoint(OcppVersion.V_16, "unauth1234", PATH);
             chargePoint.start();
         });
 

--- a/src/test/java/de/rwth/idsg/steve/OperationalTestSoapOCPP16.java
+++ b/src/test/java/de/rwth/idsg/steve/OperationalTestSoapOCPP16.java
@@ -20,7 +20,6 @@ package de.rwth.idsg.steve;
 
 import de.rwth.idsg.steve.ocpp.OcppProtocol;
 import de.rwth.idsg.steve.ocpp.soap.MessageHeaderInterceptor;
-import de.rwth.idsg.steve.ocpp.ws.OcppWebSocketUpgrader;
 import de.rwth.idsg.steve.repository.ReservationStatus;
 import de.rwth.idsg.steve.repository.dto.ChargePoint;
 import de.rwth.idsg.steve.repository.dto.ConnectorStatus;

--- a/src/test/java/de/rwth/idsg/steve/utils/OcppJsonChargePoint.java
+++ b/src/test/java/de/rwth/idsg/steve/utils/OcppJsonChargePoint.java
@@ -124,14 +124,16 @@ public class OcppJsonChargePoint {
     public void start() {
         try {
             ClientUpgradeRequest request = new ClientUpgradeRequest();
-            request.setSubProtocols(version.getValue());
+            if (version != null) {
+                request.setSubProtocols(version.getValue());
+            }
 
             client.start();
 
             Future<Session> connect = client.connect(this, new URI(connectionPath), request);
             connect.get(); // block until session is created
         } catch (Throwable t) {
-            log.error("Exception", t);
+            throw new RuntimeException(t);
         }
     }
 

--- a/src/test/java/de/rwth/idsg/steve/utils/OcppJsonChargePoint.java
+++ b/src/test/java/de/rwth/idsg/steve/utils/OcppJsonChargePoint.java
@@ -64,7 +64,7 @@ import java.util.function.Consumer;
 @WebSocket
 public class OcppJsonChargePoint {
 
-    private final OcppVersion version;
+    private final String version;
     private final String chargeBoxId;
     private final String connectionPath;
     private final Map<String, ResponseContext> responseContextMap;
@@ -76,7 +76,11 @@ public class OcppJsonChargePoint {
     private Session session;
 
     public OcppJsonChargePoint(OcppVersion version, String chargeBoxId, String pathPrefix) {
-        this.version = version;
+        this(version.getValue(), chargeBoxId, pathPrefix);
+    }
+
+    public OcppJsonChargePoint(String ocppVersion, String chargeBoxId, String pathPrefix) {
+        this.version = ocppVersion;
         this.chargeBoxId = chargeBoxId;
         this.connectionPath = pathPrefix + chargeBoxId;
         this.responseContextMap = new LinkedHashMap<>(); // because we want to keep the insertion order of test cases
@@ -125,7 +129,7 @@ public class OcppJsonChargePoint {
         try {
             ClientUpgradeRequest request = new ClientUpgradeRequest();
             if (version != null) {
-                request.setSubProtocols(version.getValue());
+                request.setSubProtocols(version);
             }
 
             client.start();


### PR DESCRIPTION
so far we were using an extension of Jetty10RequestUpgradeStrategy that did some checks and allowed the upgrade to happen or not. this had some issues:
- custom logic was a low-level interception and control mechanism touching the inner layers of spring. for example, this low-level nature became a problem when migrating from jetty 9.x to 10.x. these layers should be left to spring, since they are moving targets, and abstract away the server types and server versions.
- the only exit mechanism was throwing a HandshakeFailureException in order to stop the handshake/upgrade process. that, for example, prevented addressing #419.

solution: move the custom logic to a HandshakeHandler that executes steve/ocpp specific logic and then (if everything is okay) delegates to a DefaultHandshakeHandler for the subsequent steps.

this gives us the flexibility to exit the handshake with the respective status code.