### PR TITLE
Add recommended, additional configuration keys for OCMF

### DIFF
--- a/src/main/java/de/rwth/idsg/steve/web/dto/ocpp/ConfigurationKeyEnum.java
+++ b/src/main/java/de/rwth/idsg/steve/web/dto/ocpp/ConfigurationKeyEnum.java
@@ -104,7 +104,17 @@ public enum ConfigurationKeyEnum {
     ChargingScheduleAllowedChargingRateUnit("comma separated list", R, newHashSet(V_16)),
     ChargingScheduleMaxPeriods("integer", R, newHashSet(V_16)),
     ConnectorSwitch3to1PhaseSupported("boolean", R, newHashSet(V_16)),
-    MaxChargingProfilesInstalled("integer", R, newHashSet(V_16));
+    MaxChargingProfilesInstalled("integer", R, newHashSet(V_16)),
+
+    // -------------------------------------------------------------------------
+    // Recommended additional configuration keys for OCMF by SAFE e.V.
+    // see https://github.com/SAFE-eV/OCMF-Open-Charge-Metering-Format/blob/master/OCMF-de.md
+    // -------------------------------------------------------------------------
+
+    // StopTransactionSignatureFormat Read or Read-Write is up to Charge Point implementation so set to RW for now
+    StopTransactionSignatureFormat("string; specific to OCMF", RW, newHashSet(V_15, V_16)),
+    StopTransactionSignatureContexts("comma separated list; specific to OCMF", RW, newHashSet(V_15, V_16)),
+    MeterValuesSignatureContexts("comma separated list; specific to OCMF", RW, newHashSet(V_15, V_16));
 
     private final String value;
     private final String text;

--- a/src/main/resources/webapp/WEB-INF/views/op-forms/GetConfigurationForm.jsp
+++ b/src/main/resources/webapp/WEB-INF/views/op-forms/GetConfigurationForm.jsp
@@ -28,7 +28,9 @@
         </td>
             <td>
                 <form:select path="confKeyList" multiple="true" size="14" >
-                    <form:options items="${ocppConfKeys}" />
+                    <c:forEach items="${ocppConfKeys}" var="k">
+                    <option value="${k.getKey()}" label="${k.getValue()}" title="${k.getValue()}">
+                    </c:forEach>
                 </form:select>
             </td>
         </tr>


### PR DESCRIPTION
The OCMF specification by SAFE e.V. recommends in the Best Practices part
three new configuration keys for OCPP, see
https://github.com/SAFE-eV/OCMF-Open-Charge-Metering-Format/blob/master/OCMF-de.md

Add these keys to the list, so that users do not need to enter it manually.

It should not harm, since OCPP clients which do not know these keys should
handle it gracefully.

Signed-off-by: Michael Heimpold <mhei@heimpold.de>