### PR TITLE
Decoupled notification service

### DIFF
--- a/src/main/java/de/rwth/idsg/steve/ocpp/ws/AbstractWebSocketEndpoint.java
+++ b/src/main/java/de/rwth/idsg/steve/ocpp/ws/AbstractWebSocketEndpoint.java
@@ -26,11 +26,11 @@ import de.rwth.idsg.steve.ocpp.ws.data.CommunicationContext;
 import de.rwth.idsg.steve.ocpp.ws.data.SessionContext;
 import de.rwth.idsg.steve.ocpp.ws.pipeline.IncomingPipeline;
 import de.rwth.idsg.steve.repository.OcppServerRepository;
-import de.rwth.idsg.steve.service.NotificationService;
 import de.rwth.idsg.steve.service.notification.OcppStationWebSocketConnected;
 import de.rwth.idsg.steve.service.notification.OcppStationWebSocketDisconnected;
 import org.joda.time.DateTime;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.web.socket.BinaryMessage;
 import org.springframework.web.socket.CloseStatus;
 import org.springframework.web.socket.PongMessage;
@@ -58,7 +58,7 @@ public abstract class AbstractWebSocketEndpoint extends ConcurrentWebSocketHandl
     @Autowired private ScheduledExecutorService service;
     @Autowired private OcppServerRepository ocppServerRepository;
     @Autowired private FutureResponseContextStore futureResponseContextStore;
-    @Autowired private NotificationService notificationService;
+    @Autowired private ApplicationEventPublisher applicationEventPublisher;
 
     public static final String CHARGEBOX_ID_KEY = "CHARGEBOX_ID_KEY";
 
@@ -74,8 +74,8 @@ public abstract class AbstractWebSocketEndpoint extends ConcurrentWebSocketHandl
     public void init(IncomingPipeline pipeline) {
         this.pipeline = pipeline;
 
-        connectedCallbackList.add((chargeBoxId) -> notificationService.ocppStationWebSocketConnected(new OcppStationWebSocketConnected(chargeBoxId)));
-        disconnectedCallbackList.add((chargeBoxId) -> notificationService.ocppStationWebSocketDisconnected(new OcppStationWebSocketDisconnected(chargeBoxId)));
+        connectedCallbackList.add((chargeBoxId) -> applicationEventPublisher.publishEvent(new OcppStationWebSocketConnected(chargeBoxId)));
+        disconnectedCallbackList.add((chargeBoxId) -> applicationEventPublisher.publishEvent(new OcppStationWebSocketDisconnected(chargeBoxId)));
     }
 
     @Override

--- a/src/main/java/de/rwth/idsg/steve/ocpp/ws/AbstractWebSocketEndpoint.java
+++ b/src/main/java/de/rwth/idsg/steve/ocpp/ws/AbstractWebSocketEndpoint.java
@@ -27,6 +27,8 @@ import de.rwth.idsg.steve.ocpp.ws.data.SessionContext;
 import de.rwth.idsg.steve.ocpp.ws.pipeline.IncomingPipeline;
 import de.rwth.idsg.steve.repository.OcppServerRepository;
 import de.rwth.idsg.steve.service.NotificationService;
+import de.rwth.idsg.steve.service.notification.OcppStationWebSocketConnected;
+import de.rwth.idsg.steve.service.notification.OcppStationWebSocketDisconnected;
 import org.joda.time.DateTime;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.socket.BinaryMessage;
@@ -72,8 +74,8 @@ public abstract class AbstractWebSocketEndpoint extends ConcurrentWebSocketHandl
     public void init(IncomingPipeline pipeline) {
         this.pipeline = pipeline;
 
-        connectedCallbackList.add((chargeBoxId) -> notificationService.ocppStationWebSocketConnected(chargeBoxId));
-        disconnectedCallbackList.add((chargeBoxId) -> notificationService.ocppStationWebSocketDisconnected(chargeBoxId));
+        connectedCallbackList.add((chargeBoxId) -> notificationService.ocppStationWebSocketConnected(new OcppStationWebSocketConnected(chargeBoxId)));
+        disconnectedCallbackList.add((chargeBoxId) -> notificationService.ocppStationWebSocketDisconnected(new OcppStationWebSocketDisconnected(chargeBoxId)));
     }
 
     @Override

--- a/src/main/java/de/rwth/idsg/steve/service/CentralSystemService16_Service.java
+++ b/src/main/java/de/rwth/idsg/steve/service/CentralSystemService16_Service.java
@@ -25,6 +25,10 @@ import de.rwth.idsg.steve.repository.dto.InsertConnectorStatusParams;
 import de.rwth.idsg.steve.repository.dto.InsertTransactionParams;
 import de.rwth.idsg.steve.repository.dto.UpdateChargeboxParams;
 import de.rwth.idsg.steve.repository.dto.UpdateTransactionParams;
+import de.rwth.idsg.steve.service.notification.OccpStationBooted;
+import de.rwth.idsg.steve.service.notification.OcppStationStatusFailure;
+import de.rwth.idsg.steve.service.notification.OcppTransactionEnded;
+import de.rwth.idsg.steve.service.notification.OcppTransactionStarted;
 import jooq.steve.db.enums.TransactionStopEventActor;
 import lombok.extern.slf4j.Slf4j;
 import ocpp.cs._2015._10.AuthorizationStatus;
@@ -77,7 +81,7 @@ public class CentralSystemService16_Service {
                                                      OcppProtocol ocppProtocol) {
 
         Optional<RegistrationStatus> status = chargePointHelperService.getRegistrationStatus(chargeBoxIdentity);
-        notificationService.ocppStationBooted(chargeBoxIdentity, status);
+        notificationService.ocppStationBooted(new OccpStationBooted(chargeBoxIdentity, status));
         DateTime now = DateTime.now();
 
         if (status.isEmpty()) {
@@ -138,8 +142,8 @@ public class CentralSystemService16_Service {
         ocppServerRepository.insertConnectorStatus(params);
 
         if (parameters.getStatus() == ChargePointStatus.FAULTED) {
-            notificationService.ocppStationStatusFailure(
-                    chargeBoxIdentity, parameters.getConnectorId(), parameters.getErrorCode().value());
+            notificationService.ocppStationStatusFailure(new OcppStationStatusFailure(
+                    chargeBoxIdentity, parameters.getConnectorId(), parameters.getErrorCode().value()));
         }
 
         return new StatusNotificationResponse();
@@ -184,7 +188,7 @@ public class CentralSystemService16_Service {
 
         int transactionId = ocppServerRepository.insertTransaction(params);
 
-        notificationService.ocppTransactionStarted(transactionId, params);
+        notificationService.ocppTransactionStarted(new OcppTransactionStarted(transactionId, params));
 
         return new StartTransactionResponse()
                 .withIdTagInfo(info)
@@ -217,7 +221,7 @@ public class CentralSystemService16_Service {
 
         ocppServerRepository.insertMeterValues(chargeBoxIdentity, parameters.getTransactionData(), transactionId);
 
-        notificationService.ocppTransactionEnded(params);
+        notificationService.ocppTransactionEnded(new OcppTransactionEnded(params));
 
         return new StopTransactionResponse().withIdTagInfo(idTagInfo);
     }

--- a/src/main/java/de/rwth/idsg/steve/service/NotificationService.java
+++ b/src/main/java/de/rwth/idsg/steve/service/NotificationService.java
@@ -32,6 +32,7 @@ import de.rwth.idsg.steve.service.notification.OcppTransactionStarted;
 import lombok.extern.slf4j.Slf4j;
 import org.joda.time.DateTime;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Service;
 
 import static de.rwth.idsg.steve.NotificationFeature.OcppStationBooted;
@@ -52,6 +53,7 @@ public class NotificationService {
 
     @Autowired private MailService mailService;
 
+    @EventListener
     public void ocppStationBooted(OccpStationBooted notification) {
         if (isDisabled(OcppStationBooted)) {
             return;
@@ -68,6 +70,7 @@ public class NotificationService {
         mailService.sendAsync(subject, addTimestamp(body));
     }
 
+    @EventListener
     public void ocppStationWebSocketConnected(OcppStationWebSocketConnected notification) {
         if (isDisabled(OcppStationWebSocketConnected)) {
             return;
@@ -78,6 +81,7 @@ public class NotificationService {
         mailService.sendAsync(subject, addTimestamp(""));
     }
 
+    @EventListener
     public void ocppStationWebSocketDisconnected(OcppStationWebSocketDisconnected notification) {
         if (isDisabled(OcppStationWebSocketDisconnected)) {
             return;
@@ -88,6 +92,7 @@ public class NotificationService {
         mailService.sendAsync(subject, addTimestamp(""));
     }
 
+    @EventListener
     public void ocppStationStatusFailure(OcppStationStatusFailure notification) {
         if (isDisabled(OcppStationStatusFailure)) {
             return;
@@ -99,6 +104,7 @@ public class NotificationService {
         mailService.sendAsync(subject, addTimestamp(body));
     }
 
+    @EventListener
     public void ocppTransactionStarted(OcppTransactionStarted notification) {
         if (isDisabled(OcppTransactionStarted)) {
             return;
@@ -109,6 +115,7 @@ public class NotificationService {
         mailService.sendAsync(subject, addTimestamp(createContent(notification.getParams())));
     }
 
+    @EventListener
     public void ocppTransactionEnded(OcppTransactionEnded notification) {
        if (isDisabled(OcppTransactionEnded)) {
             return;

--- a/src/main/java/de/rwth/idsg/steve/service/notification/OccpStationBooted.java
+++ b/src/main/java/de/rwth/idsg/steve/service/notification/OccpStationBooted.java
@@ -1,0 +1,12 @@
+package de.rwth.idsg.steve.service.notification;
+
+import java.util.Optional;
+import lombok.Data;
+import ocpp.cs._2015._10.RegistrationStatus;
+
+@Data
+public class OccpStationBooted {
+
+  private final String chargeBoxId;
+  private final Optional<RegistrationStatus> status;
+}

--- a/src/main/java/de/rwth/idsg/steve/service/notification/OcppStationStatusFailure.java
+++ b/src/main/java/de/rwth/idsg/steve/service/notification/OcppStationStatusFailure.java
@@ -1,0 +1,11 @@
+package de.rwth.idsg.steve.service.notification;
+
+import lombok.Data;
+
+@Data
+public class OcppStationStatusFailure {
+
+  private final String chargeBoxId;
+  private final int connectorId;
+  private final String errorCode;
+}

--- a/src/main/java/de/rwth/idsg/steve/service/notification/OcppStationWebSocketConnected.java
+++ b/src/main/java/de/rwth/idsg/steve/service/notification/OcppStationWebSocketConnected.java
@@ -1,0 +1,9 @@
+package de.rwth.idsg.steve.service.notification;
+
+import lombok.Data;
+
+@Data
+public class OcppStationWebSocketConnected {
+
+  private final String chargeBoxId;
+}

--- a/src/main/java/de/rwth/idsg/steve/service/notification/OcppStationWebSocketDisconnected.java
+++ b/src/main/java/de/rwth/idsg/steve/service/notification/OcppStationWebSocketDisconnected.java
@@ -1,0 +1,9 @@
+package de.rwth.idsg.steve.service.notification;
+
+import lombok.Data;
+
+@Data
+public class OcppStationWebSocketDisconnected {
+
+  private final String chargeBoxId;
+}

--- a/src/main/java/de/rwth/idsg/steve/service/notification/OcppTransactionEnded.java
+++ b/src/main/java/de/rwth/idsg/steve/service/notification/OcppTransactionEnded.java
@@ -1,0 +1,10 @@
+package de.rwth.idsg.steve.service.notification;
+
+import de.rwth.idsg.steve.repository.dto.UpdateTransactionParams;
+import lombok.Data;
+
+@Data
+public class OcppTransactionEnded {
+
+  private final UpdateTransactionParams params;
+}

--- a/src/main/java/de/rwth/idsg/steve/service/notification/OcppTransactionStarted.java
+++ b/src/main/java/de/rwth/idsg/steve/service/notification/OcppTransactionStarted.java
@@ -1,0 +1,11 @@
+package de.rwth.idsg.steve.service.notification;
+
+import de.rwth.idsg.steve.repository.dto.InsertTransactionParams;
+import lombok.Data;
+
+@Data
+public class OcppTransactionStarted {
+
+  private final int transactionId;
+  private final InsertTransactionParams params;
+}


### PR DESCRIPTION
The objective of having a decoupled notification service is to allow adding some other notification service (ie: a SlackNotificationService) without any change in the business code.
